### PR TITLE
Upgrade pg admin

### DIFF
--- a/docs/examples/postgres/quickstart/pgadmin.yaml
+++ b/docs/examples/postgres/quickstart/pgadmin.yaml
@@ -25,9 +25,9 @@ spec:
         - name: PGADMIN_DEFAULT_PASSWORD
           value: "admin"
         - name: PGADMIN_PORT
-          value: "5050"
+          value: "80"
         ports:
-        - containerPort: 5050
+        - containerPort: 80
           name: http
           protocol: TCP
 ---

--- a/docs/examples/postgres/quickstart/pgadmin.yaml
+++ b/docs/examples/postgres/quickstart/pgadmin.yaml
@@ -16,12 +16,16 @@ spec:
         app: pgadmin
     spec:
       containers:
-      - args:
-        - admin
-        - admin
-        image: appscode/pgadmin:4-1.0
+      - image: dpage/pgadmin4:3
         imagePullPolicy: Always
         name: pgadmin
+        env:
+        - name: PGADMIN_DEFAULT_EMAIL
+          value: "admin"
+        - name: PGADMIN_DEFAULT_PASSWORD
+          value: "admin"
+        - name: PGADMIN_PORT
+          value: "5050"
         ports:
         - containerPort: 5050
           name: http


### PR DESCRIPTION
This PR updates pgadmin4 to the latest official version. The image used is the official image found here: https://www.pgadmin.org/download/pgadmin-4-container/

One problem with this image is it only exposes port 80 and 443.

Fixes https://github.com/kubedb/project/issues/25