### PR TITLE
Use liveness probe

### DIFF
--- a/chart/kubedb/templates/deployment.yaml
+++ b/chart/kubedb/templates/deployment.yaml
@@ -61,6 +61,16 @@ spec:
             path: /healthz
             port: 8443
             scheme: HTTPS
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           requests:
             cpu: "100m"

--- a/hack/deploy/operator.yaml
+++ b/hack/deploy/operator.yaml
@@ -51,6 +51,16 @@ spec:
             path: /healthz
             port: 8443
             scheme: HTTPS
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
- Sometimes pod stops to receive readiness probe requests (at least `log` says so). And, the readiness probe keep failing. So, liveness probe is a way to recover from this situation.
- The liveness probe specs are identical to `kube-apiserve` liveness probe specs. 