### PR TITLE
user -> username in the mysql secret and references to it

### DIFF
--- a/docs/guides/mysql/quickstart/quickstart.md
+++ b/docs/guides/mysql/quickstart/quickstart.md
@@ -170,7 +170,7 @@ Type:  Opaque
 Data
 ====
   password:  16 bytes
-  user:      4 bytes
+  username:  4 bytes
 
 No Snapshots.
 
@@ -249,9 +249,9 @@ status:
   phase: Running
 ```
 
-Please note that KubeDB operator has created a new Secret called `mysql-quickstart-auth` *(format: {mysql-object-name}-auth)* for storing the password for `mysql` superuser. This secret contains a `user` key which contains the *username* for MySQL superuser and a `password` key which contains the *password* for MySQL superuser.
+Please note that KubeDB operator has created a new Secret called `mysql-quickstart-auth` *(format: {mysql-object-name}-auth)* for storing the password for `mysql` superuser. This secret contains a `username` key which contains the *username* for MySQL superuser and a `password` key which contains the *password* for MySQL superuser.
 
-If you want to use an existing secret please specify that when creating the MySQL object using `spec.databaseSecret.secretName`. While creating this secret manually, make sure the secret contains these two keys containing data `user` and `password` and also make sure of using `root` as value of `user`. For more details see [here](/docs/concepts/databases/mysql.md#specdatabasesecret).
+If you want to use an existing secret please specify that when creating the MySQL object using `spec.databaseSecret.secretName`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [here](/docs/concepts/databases/mysql.md#specdatabasesecret).
 
 Now, you can connect to this database from the phpMyAdmin dashboard using the database pod IP and and `mysql` user password.
 
@@ -260,7 +260,7 @@ $ kubectl get pods mysql-quickstart-0 -n demo -o yaml | grep IP
   hostIP: 10.0.2.15
   podIP: 172.17.0.6
 
-$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.\user}' | base64 -d
+$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.\username}' | base64 -d
 root
 
 $ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.\password}' | base64 -d


### PR DESCRIPTION
Running kubedb 0.9.0, the secret has the keys `username` and `password` although the docs say that the key for the username is `user`. This PR updates the references to the username from `user` to `username` to reflect what it is actually called.