### PR TITLE
Fix: Missing rbac role for 'authorization.kubedb.com' api group

### DIFF
--- a/chart/kubedb/templates/cluster-role.yaml
+++ b/chart/kubedb/templates/cluster-role.yaml
@@ -88,6 +88,7 @@ rules:
 - apiGroups:
   - kubedb.com
   - catalog.kubedb.com
+  - authorization.kubedb.com
   resources:
   - "*"
   verbs: ["*"]

--- a/hack/deploy/rbac-list.yaml
+++ b/hack/deploy/rbac-list.yaml
@@ -87,6 +87,7 @@ rules:
 - apiGroups:
   - kubedb.com
   - catalog.kubedb.com
+  - authorization.kubedb.com
   resources:
   - "*"
   verbs: ["*"]


### PR DESCRIPTION
xref: https://github.com/kubedb/postgres/pull/247/files#diff-3c862eb54a8e0e161b534e0c67e5379eR97