### PR TITLE
use default values for postgres leaderelection and termination

### DIFF
--- a/docs/concepts/databases/postgres.md
+++ b/docs/concepts/databases/postgres.md
@@ -36,9 +36,9 @@ spec:
   standbyMode: Hot
   streamingMode: asynchronous
   leaderElection:
-    leaseDurationSeconds: 3
-    renewDeadlineSeconds: 2
-    retryPeriodSeconds: 1
+    leaseDurationSeconds: 15
+    renewDeadlineSeconds: 10
+    retryPeriodSeconds: 2
   archiver:
     storage:
       storageSecretName: s3-secret
@@ -118,7 +118,7 @@ spec:
         targetPort: http
   updateStrategy:
     type: RollingUpdate
-  terminationPolicy: "DoNotTerminate"
+  terminationPolicy: "Pause"
 ```
 
 ### spec.version


### PR DESCRIPTION
This is for people (like me) who copy from the example without actually reading up on all the defaults. :-)

The `leaderElection` settings of the example postgres document are very likely too short almost everywhere, so I suggest to set them to their corresponding default values.

While going through the spec I also saw `terminationPolicy` was set to a non-default value.