### PR TITLE
Prepare for release v0.14.0-beta.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20201008012351-6d8090f759d4
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201022103441-f51a42fb9ac8
 	kmodules.xyz/objectstore-api v0.0.0-20200922210707-59bab27e5d41
-	kubedb.dev/apimachinery v0.14.0-beta.4.0.20201025093720-ecfb5d85ea71
+	kubedb.dev/apimachinery v0.14.0-beta.5
 	stash.appscode.dev/apimachinery v0.11.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1459,8 +1459,8 @@ kmodules.xyz/openshift v0.0.0-20200922211657-1ece16d36c18/go.mod h1:kOnEGdrj+DxT
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2Yc8ei32uf9PxEbuwGLQm0=
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-beta.4.0.20201025093720-ecfb5d85ea71 h1:LpWbiRHxrQgeD6sraSIw0jfvFQnf7dfXl1mql7bSbYM=
-kubedb.dev/apimachinery v0.14.0-beta.4.0.20201025093720-ecfb5d85ea71/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
+kubedb.dev/apimachinery v0.14.0-beta.5 h1:CwLMgJCHrztN+ouaYl7PDZS4UB1aybLVifvsGCYm9Ms=
+kubedb.dev/apimachinery v0.14.0-beta.5/go.mod h1:3/Dy8tn3ScoG3MnPKa8Ac0CDBqOuLo2r01BI3GVHgjM=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -77,7 +77,6 @@ const (
 	ElasticsearchStatusYellow                    = "yellow"
 	ElasticsearchStatusRed                       = "red"
 
-	// =========================== MongoDB Constants ============================
 	// Ref:
 	//	- https://www.elastic.co/guide/en/elasticsearch/reference/7.6/heap-size.html#heap-size
 	//	- no more than 50% of your physical RAM
@@ -88,16 +87,26 @@ const (
 	// 128MB
 	ElasticsearchMinHeapSize = 128 * 1024 * 1024
 
-	MongoDBShardPort           = 27017
-	MongoDBConfigdbPort        = 27017
-	MongoDBMongosPort          = 27017
-	MongoDBKeyFileSecretSuffix = "key"
-	MongoDBRootUsername        = "root"
-	MongoDBCustomConfigFile    = "mongod.conf"
+	// =========================== Memcached Constants ============================
+	MemcachedDatabasePortName       = "db"
+	MemcachedPrimaryServicePortName = "primary"
+	MemcachedDatabasePort           = 11211
+
+	// =========================== MongoDB Constants ============================
+
+	MongoDBDatabasePortName       = "db"
+	MongoDBPrimaryServicePortName = "primary"
+	MongoDBDatabasePort           = 27017
+	MongoDBKeyFileSecretSuffix    = "key"
+	MongoDBRootUsername           = "root"
+	MongoDBCustomConfigFile       = "mongod.conf"
 
 	// =========================== MySQL Constants ============================
 	MySQLMetricsExporterConfigSecretSuffix = "metrics-exporter-config"
-	MySQLNodePort                          = 3306
+	MySQLDatabasePortName                  = "db"
+	MySQLPrimaryServicePortName            = "primary"
+	MySQLStandbyServicePortName            = "standby"
+	MySQLDatabasePort                      = 3306
 	MySQLGroupComPort                      = 33060
 	MySQLMaxGroupMembers                   = 9
 	// The recommended MySQL server version for group replication (GR)
@@ -115,8 +124,8 @@ const (
 
 	MySQLContainerReplicationModeDetectorName = "replication-mode-detector"
 	MySQLPodPrimary                           = "primary"
-	MySQLPodSecondary                         = "secondary"
-	MySQLLabelRole                            = MySQLKey + "/role"
+	MySQLPodStandby                           = "standby"
+	MySQLLabelRole                            = kubedb.GroupName + "/role"
 
 	MySQLTLSConfigCustom     = "custom"
 	MySQLTLSConfigSkipVerify = "skip-verify"
@@ -135,27 +144,46 @@ const (
 	PerconaXtraDBCustomConfigMountPath        = "/etc/percona-server.conf.d/"
 	PerconaXtraDBClusterCustomConfigMountPath = "/etc/percona-xtradb-cluster.conf.d/"
 
-	// =========================== LabelProxySQL Constants ============================
+	// =========================== PostgreSQL Constants ============================
+	PostgresDatabasePortName       = "db"
+	PostgresPrimaryServicePortName = "primary"
+	PostgresStandbyServicePortName = "standby"
+	PostgresDatabasePort           = 5432
+	PostgresPodPrimary             = "primary"
+	PostgresPodStandby             = "standby"
+	PostgresLabelRole              = kubedb.GroupName + "/role"
+
+	// =========================== ProxySQL Constants ============================
 	LabelProxySQLName        = ProxySQLKey + "/name"
 	LabelProxySQLLoadBalance = ProxySQLKey + "/load-balance"
 
-	ProxySQLMySQLNodePort         = 6033
-	ProxySQLAdminPort             = 6032
-	ProxySQLAdminPortName         = "admin"
-	ProxySQLDataMountPath         = "/var/lib/proxysql"
-	ProxySQLCustomConfigMountPath = "/etc/custom-config"
+	ProxySQLDatabasePort           = 6033
+	ProxySQLDatabasePortName       = "db"
+	ProxySQLPrimaryServicePortName = "db"
+	ProxySQLAdminPort              = 6032
+	ProxySQLAdminPortName          = "admin"
+	ProxySQLDataMountPath          = "/var/lib/proxysql"
+	ProxySQLCustomConfigMountPath  = "/etc/custom-config"
 
 	// =========================== Redis Constants ============================
-	RedisShardKey   = RedisKey + "/shard"
-	RedisNodePort   = 6379
-	RedisGossipPort = 16379
+	RedisShardKey               = RedisKey + "/shard"
+	RedisDatabasePortName       = "db"
+	RedisPrimaryServicePortName = "primary"
+	RedisDatabasePort           = 6379
+	RedisGossipPortName         = "gossip"
+	RedisGossipPort             = 16379
 
 	RedisKeyFileSecretSuffix = "key"
 	RedisPEMSecretSuffix     = "pem"
 	RedisRootUsername        = "root"
 
 	// =========================== PgBouncer Constants ============================
-	PgBouncerUpstreamServerCA = "upstream-server-ca.crt"
+	PgBouncerUpstreamServerCA       = "upstream-server-ca.crt"
+	PgBouncerDatabasePortName       = "db"
+	PgBouncerPrimaryServicePortName = "primary"
+	PgBouncerDatabasePort           = 5432
+	PgBouncerConfigFile             = "pgbouncer.ini"
+	PgBouncerAdminUsername          = "kubedb"
 )
 
 // List of possible condition types for a KubeDB object

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
@@ -94,9 +94,8 @@ func (e *Elasticsearch) MasterServiceName() string {
 	return meta_util.NameWithSuffix(e.ServiceName(), "master")
 }
 
-// Governing Service Name
-func (e Elasticsearch) GvrSvcName() string {
-	return meta_util.NameWithSuffix(e.OffshootName(), "gvr")
+func (e Elasticsearch) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(e.ServiceName(), "pods")
 }
 
 // CertificateName returns the default certificate name and/or certificate secret name for a certificate alias

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mariadb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mariadb_helpers.go
@@ -80,7 +80,7 @@ func (m MariaDB) ServiceName() string {
 }
 
 func (m MariaDB) GoverningServiceName() string {
-	return m.OffshootName() + "-gvr"
+	return meta_util.NameWithSuffix(m.ServiceName(), "pods")
 }
 
 type mariadbApp struct {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/memcached_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/memcached_helpers.go
@@ -78,6 +78,10 @@ func (m Memcached) ServiceName() string {
 	return m.OffshootName()
 }
 
+func (m Memcached) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(m.ServiceName(), "pods")
+}
+
 type memcachedApp struct {
 	*Memcached
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -196,11 +196,11 @@ func (m MongoDB) ServiceName() string {
 
 // Governing Service Name. Here, name parameter is either
 // OffshootName, ShardNodeName or ConfigSvrNodeName
-func (m MongoDB) GvrSvcName(name string) string {
+func (m MongoDB) GoverningServiceName(name string) string {
 	if name == "" {
 		panic(fmt.Sprintf("StatefulSet name is missing for MongoDB %s/%s", m.Namespace, m.Name))
 	}
-	return name + "-gvr"
+	return name + "-pods"
 }
 
 // HostAddress returns serviceName for standalone mongodb.
@@ -218,11 +218,11 @@ func (m MongoDB) HostAddress() string {
 }
 
 func (m MongoDB) Hosts() []string {
-	hosts := []string{fmt.Sprintf("%v-0.%v.%v.svc", m.Name, m.GvrSvcName(m.OffshootName()), m.Namespace)}
+	hosts := []string{fmt.Sprintf("%v-0.%v.%v.svc", m.Name, m.GoverningServiceName(m.OffshootName()), m.Namespace)}
 	if m.Spec.ReplicaSet != nil {
 		hosts = make([]string, *m.Spec.Replicas)
 		for i := 0; i < int(types.Int32(m.Spec.Replicas)); i++ {
-			hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc", m.Name, i, m.GvrSvcName(m.OffshootName()), m.Namespace)
+			hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc", m.Name, i, m.GoverningServiceName(m.OffshootName()), m.Namespace)
 		}
 	}
 	return hosts
@@ -243,7 +243,7 @@ func (m MongoDB) ShardHosts(nodeNum int32) []string {
 	}
 	hosts := make([]string, m.Spec.ShardTopology.Shard.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.Shard.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ShardNodeName(nodeNum), i, m.GvrSvcName(m.ShardNodeName(nodeNum)), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ShardNodeName(nodeNum), i, m.GoverningServiceName(m.ShardNodeName(nodeNum)), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }
@@ -265,7 +265,7 @@ func (m MongoDB) ConfigSvrHosts() []string {
 
 	hosts := make([]string, m.Spec.ShardTopology.ConfigServer.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.ConfigServer.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ConfigSvrNodeName(), i, m.GvrSvcName(m.ConfigSvrNodeName()), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.ConfigSvrNodeName(), i, m.GoverningServiceName(m.ConfigSvrNodeName()), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }
@@ -277,7 +277,7 @@ func (m MongoDB) MongosHosts() []string {
 
 	hosts := make([]string, m.Spec.ShardTopology.Mongos.Replicas)
 	for i := 0; i < int(m.Spec.ShardTopology.Mongos.Replicas); i++ {
-		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.MongosNodeName(), i, m.GvrSvcName(m.MongosNodeName()), m.Namespace, MongoDBShardPort)
+		hosts[i] = fmt.Sprintf("%v-%d.%v.%v.svc:%v", m.MongosNodeName(), i, m.GoverningServiceName(m.MongosNodeName()), m.Namespace, MongoDBDatabasePort)
 	}
 	return hosts
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mysql_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mysql_helpers.go
@@ -81,12 +81,12 @@ func (m MySQL) ServiceName() string {
 	return m.OffshootName()
 }
 
-func (m MySQL) SecondaryServiceName() string {
-	return meta_util.NameWithPrefix(m.ServiceName(), "replicas")
+func (m MySQL) StandbyServiceName() string {
+	return meta_util.NameWithPrefix(m.ServiceName(), "standby")
 }
 
 func (m MySQL) GoverningServiceName() string {
-	return m.OffshootName() + "-gvr"
+	return meta_util.NameWithSuffix(m.ServiceName(), "pods")
 }
 
 func (m MySQL) PeerName(idx int) string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
@@ -85,7 +85,7 @@ func (p PerconaXtraDB) IsCluster() bool {
 }
 
 func (p PerconaXtraDB) GoverningServiceName() string {
-	return p.OffshootName() + "-gvr"
+	return meta_util.NameWithSuffix(p.ServiceName(), "pods")
 }
 
 func (p PerconaXtraDB) PeerName(idx int) string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
@@ -79,6 +79,18 @@ func (p PgBouncer) ServiceName() string {
 	return p.OffshootName()
 }
 
+func (p PgBouncer) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "pods")
+}
+
+func (p PgBouncer) AuthSecretName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "auth")
+}
+
+func (p PgBouncer) ConfigSecretName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "config")
+}
+
 type pgbouncerApp struct {
 	*PgBouncer
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/postgres_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/postgres_helpers.go
@@ -79,6 +79,14 @@ func (p Postgres) ServiceName() string {
 	return p.OffshootName()
 }
 
+func (p Postgres) StandbyServiceName() string {
+	return meta_util.NameWithPrefix(p.ServiceName(), "standby")
+}
+
+func (p Postgres) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "pods")
+}
+
 type postgresApp struct {
 	*Postgres
 }
@@ -131,10 +139,6 @@ func (p Postgres) StatsServiceLabels() map[string]string {
 	lbl := meta_util.FilterKeys(kubedb.GroupName, p.OffshootSelectors(), p.Labels)
 	lbl[LabelRole] = RoleStats
 	return lbl
-}
-
-func (p Postgres) ReplicasServiceName() string {
-	return fmt.Sprintf("%v-replicas", p.Name)
 }
 
 func (p *Postgres) SetDefaults() {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
@@ -80,6 +80,10 @@ func (p ProxySQL) ServiceName() string {
 	return p.OffshootName()
 }
 
+func (p ProxySQL) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(p.ServiceName(), "pods")
+}
+
 type proxysqlApp struct {
 	*ProxySQL
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
@@ -88,6 +88,10 @@ func (r Redis) ServiceName() string {
 	return r.OffshootName()
 }
 
+func (r Redis) GoverningServiceName() string {
+	return meta_util.NameWithSuffix(r.ServiceName(), "pods")
+}
+
 func (r Redis) ConfigSecretName() string {
 	return r.OffshootName()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ kmodules.xyz/objectstore-api/api/v1
 kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.14.0-beta.4.0.20201025093720-ecfb5d85ea71
+# kubedb.dev/apimachinery v0.14.0-beta.5
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.26-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>