### PR TITLE
Prepare for release v0.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20210812193424-1631fae03a1a
 	kmodules.xyz/monitoring-agent-api v0.0.0-20210618110729-9cd872c66513
 	kmodules.xyz/objectstore-api v0.0.0-20210816212508-b1e60a2fd3a0 // indirect
-	kubedb.dev/apimachinery v0.19.1-0.20210816225014-a8eb885ccaa2
+	kubedb.dev/apimachinery v0.20.0
 	stash.appscode.dev/apimachinery v0.14.2-0.20210715200631-5399637188c0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1184,8 +1184,8 @@ kmodules.xyz/resource-metadata v0.5.7/go.mod h1:Jdi7zBXRwwFTOR0CxwKxqJhsDVIilhrg
 kmodules.xyz/resource-metadata v0.5.8-0.20210812062826-71d20972a852/go.mod h1:FpXWUvVESesHlaexlwqQvdI5Vtl8DCBcmBPWTVpiyn0=
 kmodules.xyz/resource-metrics v0.0.1/go.mod h1:5nlhi7MPPr09m7VblezHSz9cE1fuUypOSLlo+aN5mrA=
 kmodules.xyz/webhook-runtime v0.0.0-20210716205500-e489faf01981/go.mod h1:MFZFmJk9IXNHwq8JlF/mukwBDbopFQj4swaB2MWHc/U=
-kubedb.dev/apimachinery v0.19.1-0.20210816225014-a8eb885ccaa2 h1:zYQduv17xK3VingIscP9UDpYWW7wrWVx4NoWVBtmCi0=
-kubedb.dev/apimachinery v0.19.1-0.20210816225014-a8eb885ccaa2/go.mod h1:RRStZ10EiF7/BM/R1ILuGbpHYQXKu07kZENnG35oNJw=
+kubedb.dev/apimachinery v0.20.0 h1:sXKvauaxxxNResrTL9IJoWeWWoFyi/jjdR484H45PiI=
+kubedb.dev/apimachinery v0.20.0/go.mod h1:RRStZ10EiF7/BM/R1ILuGbpHYQXKu07kZENnG35oNJw=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/elasticsearch_version_types.go
+++ b/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/elasticsearch_version_types.go
@@ -126,11 +126,12 @@ const (
 	ElasticsearchAuthPluginXpack       ElasticsearchAuthPlugin = "X-Pack"
 )
 
-// +kubebuilder:validation:Enum=ElasticStack;OpenDistro;SearchGuard
+// +kubebuilder:validation:Enum=ElasticStack;OpenDistro;SearchGuard;KubeDB
 type ElasticsearchDistro string
 
 const (
 	ElasticsearchDistroElasticStack ElasticsearchDistro = "ElasticStack"
 	ElasticsearchDistroOpenDistro   ElasticsearchDistro = "OpenDistro"
 	ElasticsearchDistroSearchGuard  ElasticsearchDistro = "SearchGuard"
+	ElasticsearchDistroKubeDB       ElasticsearchDistro = "KubeDB"
 )

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -268,6 +268,8 @@ const (
 	RedisKeyFileSecretSuffix = "key"
 	RedisPEMSecretSuffix     = "pem"
 	RedisRootUsername        = "root"
+	EnvRedisUser             = "USERNAME"
+	EnvRedisPassword         = "REDISCLI_AUTH"
 
 	// =========================== PgBouncer Constants ============================
 	PgBouncerUpstreamServerCA       = "upstream-server-ca.crt"

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
@@ -215,7 +215,15 @@ func (r *Redis) SetTLSDefaults() {
 }
 
 func (r *RedisSpec) GetPersistentSecrets() []string {
-	return nil
+	if r == nil {
+		return nil
+	}
+
+	var secrets []string
+	if r.AuthSecret != nil {
+		secrets = append(secrets, r.AuthSecret.Name)
+	}
+	return secrets
 }
 
 func (r *Redis) setDefaultAffinity(podTemplate *ofst.PodTemplateSpec, labels map[string]string, topology *core_util.Topology) {

--- a/vendor/kubedb.dev/apimachinery/crds/catalog.kubedb.com_elasticsearchversions.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/catalog.kubedb.com_elasticsearchversions.yaml
@@ -68,6 +68,7 @@ spec:
                 - ElasticStack
                 - OpenDistro
                 - SearchGuard
+                - KubeDB
                 type: string
               exporter:
                 properties:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -608,7 +608,7 @@ kmodules.xyz/objectstore-api/api/v1
 kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.19.1-0.20210816225014-a8eb885ccaa2
+# kubedb.dev/apimachinery v0.20.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.08.23
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/40
Signed-off-by: 1gtm <1gtm@appscode.com>