### PR TITLE
Prepare for release v0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20211025144742-7ab2db03cce8
 	kmodules.xyz/monitoring-agent-api v0.0.0-20211117051609-520052fe6ff6
 	kmodules.xyz/objectstore-api v0.0.0-20211025143832-b9135743b78b // indirect
-	kubedb.dev/apimachinery v0.22.1-0.20211116190956-ff3a4175f2df
+	kubedb.dev/apimachinery v0.23.0
 	stash.appscode.dev/apimachinery v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1199,8 +1199,8 @@ kmodules.xyz/resource-metadata v0.6.4/go.mod h1:KWf68Ado/hgYpb/msYNvhYSLWvS/bJcV
 kmodules.xyz/resource-metrics v0.0.3/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
 kmodules.xyz/resource-metrics v0.0.5/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
 kmodules.xyz/webhook-runtime v0.0.0-20210928141616-7f73c2ab318a/go.mod h1:MFZFmJk9IXNHwq8JlF/mukwBDbopFQj4swaB2MWHc/U=
-kubedb.dev/apimachinery v0.22.1-0.20211116190956-ff3a4175f2df h1:CJs3eLX6AqrdY0h7yapB3ABl2tVHa1P+ruLQukflquA=
-kubedb.dev/apimachinery v0.22.1-0.20211116190956-ff3a4175f2df/go.mod h1:x8UBaJPIBCD6S58VQ+38+QxFUXCYdvFrmP9FnOuPOaI=
+kubedb.dev/apimachinery v0.23.0 h1:K0dKXx7XJINv3Py75D/up6V3zl8XfX/e/rvspNejXNA=
+kubedb.dev/apimachinery v0.23.0/go.mod h1:x8UBaJPIBCD6S58VQ+38+QxFUXCYdvFrmP9FnOuPOaI=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -621,7 +621,7 @@ kmodules.xyz/objectstore-api/api/v1
 kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.22.1-0.20211116190956-ff3a4175f2df
+# kubedb.dev/apimachinery v0.23.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.11.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/45
Signed-off-by: 1gtm <1gtm@appscode.com>