### PR TITLE
Prepare for release v0.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20211117051609-520052fe6ff6
 	kmodules.xyz/objectstore-api v0.0.0-20211116180107-8720be0c9bf7 // indirect
 	kmodules.xyz/offshoot-api v0.0.0-20211116180130-806cde7fb795 // indirect
-	kubedb.dev/apimachinery v0.23.1-0.20211122140200-fe94664c6645
+	kubedb.dev/apimachinery v0.24.0
 	stash.appscode.dev/apimachinery v0.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1202,8 +1202,8 @@ kmodules.xyz/resource-metadata v0.6.4/go.mod h1:KWf68Ado/hgYpb/msYNvhYSLWvS/bJcV
 kmodules.xyz/resource-metrics v0.0.3/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
 kmodules.xyz/resource-metrics v0.0.5/go.mod h1:6Dv63HDgp83DhA+lZNB7GIQR6PLjNrYW6ghQKioQzII=
 kmodules.xyz/webhook-runtime v0.0.0-20210928141616-7f73c2ab318a/go.mod h1:MFZFmJk9IXNHwq8JlF/mukwBDbopFQj4swaB2MWHc/U=
-kubedb.dev/apimachinery v0.23.1-0.20211122140200-fe94664c6645 h1:pzzMygnBdzkAFPmcnDWI0kPRVYfEc3rfdpGCQ3RsTvQ=
-kubedb.dev/apimachinery v0.23.1-0.20211122140200-fe94664c6645/go.mod h1:euSlEJ4PbfR6m6QH1oYGt2bEAOErr/ZiJWz+h+siqII=
+kubedb.dev/apimachinery v0.24.0 h1:yYHsPoM+c32K7jo5DRZ18qr+aGaTXfVoOWkpP4//FIY=
+kubedb.dev/apimachinery v0.24.0/go.mod h1:euSlEJ4PbfR6m6QH1oYGt2bEAOErr/ZiJWz+h+siqII=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -622,7 +622,7 @@ kmodules.xyz/objectstore-api/api/v1
 kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.23.1-0.20211122140200-fe94664c6645
+# kubedb.dev/apimachinery v0.24.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.11.24
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/46
Signed-off-by: 1gtm <1gtm@appscode.com>