### PR TITLE
Prepare for release v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	kmodules.xyz/client-go v0.0.0-20220512223652-dc247aa7f6df
 	kmodules.xyz/custom-resources v0.0.0-20220422215041-237eae1d7ddd
 	kmodules.xyz/monitoring-agent-api v0.0.0-20220519191512-5a48a0a1d3f8
-	kubedb.dev/apimachinery v0.26.1-0.20220519193141-3634eb14c9ac
+	kubedb.dev/apimachinery v0.27.0
 	stash.appscode.dev/apimachinery v0.20.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ kmodules.xyz/resource-metrics v0.0.8/go.mod h1:M7rWuo2qh3BpHhogiEVPnvGY9Xx4Pfygq
 kmodules.xyz/schema-checker v0.2.0/go.mod h1:J1QUIFsqW0h/WNrIGzzy3UopTzg+RmMJXxvAZfmYDb4=
 kmodules.xyz/schema-checker v0.2.1/go.mod h1:1R2s4FH23Rz73DnfT8paWGNeMQpT7ia3KoyF8X4HCGU=
 kmodules.xyz/webhook-runtime v0.0.0-20220317222714-0ddfc9e4c221/go.mod h1:Q+4LHbCHVlkKxpEgaDa/EyZb5p/Bpj767zInBwyyitc=
-kubedb.dev/apimachinery v0.26.1-0.20220519193141-3634eb14c9ac h1:xdQ7eCssD8CrmofM/8hWgkhP96f21wYvE2dCQikjzvE=
-kubedb.dev/apimachinery v0.26.1-0.20220519193141-3634eb14c9ac/go.mod h1:atLQjkN5sVQc7WJJCyxTt0AD8ZODyZYUxudYAQIxL2Y=
+kubedb.dev/apimachinery v0.27.0 h1:+qrUhjnI5iXGQrBA5m6UUTBU75OxVtMY8k2V4UIoQJU=
+kubedb.dev/apimachinery v0.27.0/go.mod h1:atLQjkN5sVQc7WJJCyxTt0AD8ZODyZYUxudYAQIxL2Y=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -758,7 +758,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20220317043828-5ae0114adcad
 ## explicit; go 1.15
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.26.1-0.20220519193141-3634eb14c9ac
+# kubedb.dev/apimachinery v0.27.0
 ## explicit; go 1.17
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.05.24
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/51
Signed-off-by: 1gtm <1gtm@appscode.com>