### PR TITLE
Prepare for release v0.29.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	kmodules.xyz/client-go v0.25.6
 	kmodules.xyz/custom-resources v0.25.1
 	kmodules.xyz/monitoring-agent-api v0.25.0
-	kubedb.dev/apimachinery v0.29.0-rc.0
+	kubedb.dev/apimachinery v0.29.0
 	stash.appscode.dev/apimachinery v0.23.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -997,8 +997,8 @@ kmodules.xyz/offshoot-api v0.25.0 h1:Svq9da/+sg5afOjpgo9vx2J/Lu90Mo0aFxkdQmgKnGI
 kmodules.xyz/offshoot-api v0.25.0/go.mod h1:ysEBn7LJuT3+s8ynAQA/OG0BSsJugXa6KGtDLMRjlKo=
 kmodules.xyz/prober v0.25.0 h1:R5uRLHJEvEtEoogj+vaTAob0Btph6+PX5IlS6hPh8PA=
 kmodules.xyz/prober v0.25.0/go.mod h1:z4RTnjaajNQa/vPltsiOnO3xI716I/ziD2ac2Exm+1M=
-kubedb.dev/apimachinery v0.29.0-rc.0 h1:mJek0RJaPkgBGue4h4BQjxQLX2wToX4RtxG5wnJSlnk=
-kubedb.dev/apimachinery v0.29.0-rc.0/go.mod h1:8/kV/429eH4DlQ24vwRaxkf1mMhN6FL/nvuPEJt2CYc=
+kubedb.dev/apimachinery v0.29.0 h1:MHsQ4Iqy4kAWGy+NRg9cRZe1VJXWKcdj0CkF+Y1DJfQ=
+kubedb.dev/apimachinery v0.29.0/go.mod h1:8/kV/429eH4DlQ24vwRaxkf1mMhN6FL/nvuPEJt2CYc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/openapi_generated.go
+++ b/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/openapi_generated.go
@@ -23569,7 +23569,6 @@ func schema_apimachinery_apis_catalog_v1alpha1_ProxySQLVersionSpec(ref common.Re
 					"exporter": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Exporter Image",
-							Default:     map[string]interface{}{},
 							Ref:         ref("kubedb.dev/apimachinery/apis/catalog/v1alpha1.ProxySQLVersionExporter"),
 						},
 					},
@@ -23595,7 +23594,7 @@ func schema_apimachinery_apis_catalog_v1alpha1_ProxySQLVersionSpec(ref common.Re
 						},
 					},
 				},
-				Required: []string{"version", "proxysql", "exporter", "podSecurityPolicies"},
+				Required: []string{"version", "proxysql", "podSecurityPolicies"},
 			},
 		},
 		Dependencies: []string{

--- a/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/proxysql_version_types.go
+++ b/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/proxysql_version_types.go
@@ -51,7 +51,7 @@ type ProxySQLVersionSpec struct {
 	// Proxysql Image
 	Proxysql ProxySQLVersionProxysql `json:"proxysql"`
 	// Exporter Image
-	Exporter ProxySQLVersionExporter `json:"exporter"`
+	Exporter *ProxySQLVersionExporter `json:"exporter,omitempty"`
 	// Deprecated versions usable but regarded as obsolete and best avoided, typically due to having been superseded.
 	// +optional
 	Deprecated bool `json:"deprecated,omitempty"`

--- a/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/kubedb.dev/apimachinery/apis/catalog/v1alpha1/zz_generated.deepcopy.go
@@ -1631,7 +1631,11 @@ func (in *ProxySQLVersionProxysql) DeepCopy() *ProxySQLVersionProxysql {
 func (in *ProxySQLVersionSpec) DeepCopyInto(out *ProxySQLVersionSpec) {
 	*out = *in
 	out.Proxysql = in.Proxysql
-	out.Exporter = in.Exporter
+	if in.Exporter != nil {
+		in, out := &in.Exporter, &out.Exporter
+		*out = new(ProxySQLVersionExporter)
+		**out = **in
+	}
 	out.PodSecurityPolicies = in.PodSecurityPolicies
 	in.UpgradeConstraints.DeepCopyInto(&out.UpgradeConstraints)
 	return

--- a/vendor/kubedb.dev/apimachinery/crds/catalog.kubedb.com_proxysqlversions.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/catalog.kubedb.com_proxysqlversions.yaml
@@ -80,7 +80,6 @@ spec:
               version:
                 type: string
             required:
-            - exporter
             - podSecurityPolicies
             - proxysql
             - version

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -765,7 +765,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.29.0-rc.0
+# kubedb.dev/apimachinery v0.29.0
 ## explicit; go 1.18
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.10.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/58
Signed-off-by: 1gtm <1gtm@appscode.com>