### PR TITLE
Prepare for release v0.30.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	kmodules.xyz/client-go v0.25.14
 	kmodules.xyz/custom-resources v0.25.1
 	kmodules.xyz/monitoring-agent-api v0.25.0
-	kubedb.dev/apimachinery v0.30.0-rc.1.0.20221224061557-c221f8b7d588
+	kubedb.dev/apimachinery v0.30.0
 	stash.appscode.dev/apimachinery v0.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -996,8 +996,8 @@ kmodules.xyz/offshoot-api v0.25.0 h1:Svq9da/+sg5afOjpgo9vx2J/Lu90Mo0aFxkdQmgKnGI
 kmodules.xyz/offshoot-api v0.25.0/go.mod h1:ysEBn7LJuT3+s8ynAQA/OG0BSsJugXa6KGtDLMRjlKo=
 kmodules.xyz/prober v0.25.0 h1:R5uRLHJEvEtEoogj+vaTAob0Btph6+PX5IlS6hPh8PA=
 kmodules.xyz/prober v0.25.0/go.mod h1:z4RTnjaajNQa/vPltsiOnO3xI716I/ziD2ac2Exm+1M=
-kubedb.dev/apimachinery v0.30.0-rc.1.0.20221224061557-c221f8b7d588 h1:ySOKDj79ySoxa3t1MFlrTZW2V7x/5YP4ysu1jtIXv60=
-kubedb.dev/apimachinery v0.30.0-rc.1.0.20221224061557-c221f8b7d588/go.mod h1:KzhkePobW6iQlaBgO2iRXN9eyAv7B+gQZUSG9CwocTo=
+kubedb.dev/apimachinery v0.30.0 h1:gZAk5KKPxp5P1IbhiuQXCN1RlXbwObfRkvySQsZYmaM=
+kubedb.dev/apimachinery v0.30.0/go.mod h1:KzhkePobW6iQlaBgO2iRXN9eyAv7B+gQZUSG9CwocTo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -767,7 +767,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.30.0-rc.1.0.20221224061557-c221f8b7d588
+# kubedb.dev/apimachinery v0.30.0
 ## explicit; go 1.18
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.12.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/62
Signed-off-by: 1gtm <1gtm@appscode.com>