### PR TITLE
Prepare for release v0.34.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	kmodules.xyz/client-go v0.25.23
 	kmodules.xyz/custom-resources v0.25.2
 	kmodules.xyz/monitoring-agent-api v0.25.1
-	kubedb.dev/apimachinery v0.33.2-0.20230503123451-70ebcf524ed7
+	kubedb.dev/apimachinery v0.34.0-rc.0
 	stash.appscode.dev/apimachinery v0.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ kmodules.xyz/offshoot-api v0.25.4 h1:IjJNvkphcdYUG8XO/pBwXpuP8W+jxAWJZ3yH8vgI/as
 kmodules.xyz/offshoot-api v0.25.4/go.mod h1:PUk4EuJFhhyQykCflHj7EgXcljGIqs9vi0IN0RpxtY4=
 kmodules.xyz/prober v0.25.0 h1:R5uRLHJEvEtEoogj+vaTAob0Btph6+PX5IlS6hPh8PA=
 kmodules.xyz/prober v0.25.0/go.mod h1:z4RTnjaajNQa/vPltsiOnO3xI716I/ziD2ac2Exm+1M=
-kubedb.dev/apimachinery v0.33.2-0.20230503123451-70ebcf524ed7 h1:v5dONAxkaDy9rBdvVpu1oX6hNijjdValKvMgalFQgGI=
-kubedb.dev/apimachinery v0.33.2-0.20230503123451-70ebcf524ed7/go.mod h1:uanD/CoIJz9Zc+so9VvD4+f1KN6MH2CrPjeHcE2ybWE=
+kubedb.dev/apimachinery v0.34.0-rc.0 h1:U8iOIZPDZVg6yYl5k/mFdH38yXh8MLESP0DyZ+Uu8ww=
+kubedb.dev/apimachinery v0.34.0-rc.0/go.mod h1:bFkJ6mbKUpmvmfVML6dczw/+BEO8AMKcuWZckydR2Y0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -379,8 +379,9 @@ const (
 	SharedBuffersMbAsKiloByte = 1024
 
 	// =========================== ProxySQL Constants ============================
-	LabelProxySQLName        = ProxySQLKey + "/name"
-	LabelProxySQLLoadBalance = ProxySQLKey + "/load-balance"
+	LabelProxySQLName                  = ProxySQLKey + "/name"
+	LabelProxySQLLoadBalance           = ProxySQLKey + "/load-balance"
+	LabelProxySQLLoadBalanceStandalone = "Standalone"
 
 	ProxySQLContainerName          = ResourceSingularProxySQL
 	ProxySQLDatabasePort           = 6033

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/openapi_generated.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/openapi_generated.go
@@ -25992,13 +25992,6 @@ func schema_apimachinery_apis_kubedb_v1alpha2_ProxySQLSpec(ref common.ReferenceC
 							Format:      "int32",
 						},
 					},
-					"mode": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Mode specifies the type of MySQL/Percona-XtraDB/MariaDB cluster for which proxysql will be configured. It must be either \"Galera\" or \"GroupReplication\"",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"backend": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Backend refers to the AppBinding of the backend MySQL/MariaDB/Percona-XtraDB server",

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
@@ -49,7 +49,6 @@ func (p ProxySQL) OffshootSelectors() map[string]string {
 		meta_util.NameLabelKey:      p.ResourceFQN(),
 		meta_util.InstanceLabelKey:  p.Name,
 		meta_util.ManagedByLabelKey: kubedb.GroupName,
-		LabelProxySQLLoadBalance:    string(*p.Spec.Mode),
 	}
 }
 
@@ -171,7 +170,7 @@ func (p *ProxySQL) SetDefaults(usesAcme bool) {
 		return
 	}
 
-	if p == nil || p.Spec.Mode == nil || p.Spec.Backend == nil {
+	if p == nil || p.Spec.Backend == nil {
 		return
 	}
 

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_types.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_types.go
@@ -137,10 +137,6 @@ type ProxySQLSpec struct {
 	// TODO: If replicas > 1, proxysql will be clustered
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Mode specifies the type of MySQL/Percona-XtraDB/MariaDB cluster for which proxysql
-	// will be configured. It must be either "Galera" or "GroupReplication"
-	Mode *LoadBalanceMode `json:"mode,omitempty"`
-
 	// Backend refers to the AppBinding of the backend MySQL/MariaDB/Percona-XtraDB server
 	Backend *core.LocalObjectReference `json:"backend,omitempty"`
 

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/zz_generated.deepcopy.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/zz_generated.deepcopy.go
@@ -2638,11 +2638,6 @@ func (in *ProxySQLSpec) DeepCopyInto(out *ProxySQLSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.Mode != nil {
-		in, out := &in.Mode, &out.Mode
-		*out = new(LoadBalanceMode)
-		**out = **in
-	}
 	if in.Backend != nil {
 		in, out := &in.Backend, &out.Backend
 		*out = new(corev1.LocalObjectReference)

--- a/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mariadbdatabase_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mariadbdatabase_helpers.go
@@ -21,6 +21,7 @@ import (
 
 	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
 	"kubedb.dev/apimachinery/crds"
+	"kubedb.dev/apimachinery/pkg/double_optin"
 
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,7 +173,7 @@ func (in *MariaDBDatabase) CheckDoubleOptIn(ctx context.Context, client client.C
 		return false, err
 	}
 
-	possible, err := CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, maria.Spec.AllowedSchemas)
+	possible, err := double_optin.CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, maria.Spec.AllowedSchemas)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mongodbdatabase_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mongodbdatabase_helpers.go
@@ -21,6 +21,7 @@ import (
 
 	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
 	"kubedb.dev/apimachinery/crds"
+	"kubedb.dev/apimachinery/pkg/double_optin"
 
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -135,7 +136,7 @@ func (in *MongoDBDatabase) CheckDoubleOptIn(ctx context.Context, client client.C
 		return false, err
 	}
 
-	possible, err := CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, mongo.Spec.AllowedSchemas)
+	possible, err := double_optin.CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, mongo.Spec.AllowedSchemas)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mysqldatabase_helper.go
+++ b/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/mysqldatabase_helper.go
@@ -21,6 +21,7 @@ import (
 
 	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
 	"kubedb.dev/apimachinery/crds"
+	"kubedb.dev/apimachinery/pkg/double_optin"
 
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,7 +173,7 @@ func (in *MySQLDatabase) CheckDoubleOptIn(ctx context.Context, client client.Cli
 		return false, err
 	}
 
-	possible, err := CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, mysql.Spec.AllowedSchemas)
+	possible, err := double_optin.CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, mysql.Spec.AllowedSchemas)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/postgresdatabase_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/schema/v1alpha1/postgresdatabase_helpers.go
@@ -22,6 +22,7 @@ import (
 
 	kdm "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
 	"kubedb.dev/apimachinery/crds"
+	"kubedb.dev/apimachinery/pkg/double_optin"
 
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -152,7 +153,7 @@ func (in *PostgresDatabase) CheckDoubleOptIn(ctx context.Context, client client.
 		return false, err
 	}
 
-	possible, err := CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, pg.Spec.AllowedSchemas)
+	possible, err := double_optin.CheckIfDoubleOptInPossible(schema.ObjectMeta, nsSchema.ObjectMeta, nsDB.ObjectMeta, pg.Spec.AllowedSchemas)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/kubedb.dev/apimachinery/crds/kubedb.com_proxysqls.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/kubedb.com_proxysqls.yaml
@@ -143,11 +143,6 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
-              mode:
-                enum:
-                - Galera
-                - GroupReplication
-                type: string
               monitor:
                 properties:
                   agent:

--- a/vendor/kubedb.dev/apimachinery/pkg/double_optin/double_optin.go
+++ b/vendor/kubedb.dev/apimachinery/pkg/double_optin/double_optin.go
@@ -1,0 +1,92 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package double_optin
+
+import (
+	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+// CheckIfDoubleOptInPossible is the intended function to be called from operator
+// It checks if the namespace, where SchemaDatabase or Archiver is applied, is allowed.
+// It also checks the labels of schemaDatabase OR archiver, to decide if that is allowed or not.
+//
+// Here, clientMeta is the ObjectMeta of SchemaDatabase or Archiver
+// & clientNSMeta is the ObjectMeta of the namespace where they belong.
+func CheckIfDoubleOptInPossible(clientMeta metav1.ObjectMeta, clientNSMeta metav1.ObjectMeta, dbNSMeta metav1.ObjectMeta, consumers *dbapi.AllowedConsumers) (bool, error) {
+	if consumers == nil {
+		return false, nil
+	}
+	matchNamespace, err := IsInAllowedNamespaces(clientNSMeta, dbNSMeta, consumers)
+	if err != nil {
+		return false, err
+	}
+	matchLabels, err := IsMatchByLabels(clientMeta, consumers)
+	if err != nil {
+		return false, err
+	}
+	return matchNamespace && matchLabels, nil
+}
+
+func IsInAllowedNamespaces(clientNSMeta metav1.ObjectMeta, dbNSMeta metav1.ObjectMeta, consumers *dbapi.AllowedConsumers) (bool, error) {
+	if consumers.Namespaces == nil || consumers.Namespaces.From == nil {
+		return false, nil
+	}
+
+	if *consumers.Namespaces.From == dbapi.NamespacesFromAll {
+		return true, nil
+	}
+	if *consumers.Namespaces.From == dbapi.NamespacesFromSame {
+		return clientNSMeta.GetName() == dbNSMeta.GetName(), nil
+	}
+	if *consumers.Namespaces.From == dbapi.NamespacesFromSelector {
+		if consumers.Namespaces.Selector == nil {
+			// this says, Select namespace from the Selector, but the Namespace.Selector field is nil. So, no way to select namespace here.
+			return false, nil
+		}
+		ret, err := selectorMatches(consumers.Namespaces.Selector, clientNSMeta.GetLabels())
+		if err != nil {
+			return false, err
+		}
+		return ret, nil
+	}
+	return false, nil
+}
+
+func IsMatchByLabels(clientMeta metav1.ObjectMeta, consumers *dbapi.AllowedConsumers) (bool, error) {
+	if consumers.Selector != nil {
+		ret, err := selectorMatches(consumers.Selector, clientMeta.Labels)
+		if err != nil {
+			return false, err
+		}
+		return ret, nil
+	}
+	// if Selector is not given, all the Schemas are allowed of the selected namespace
+	return true, nil
+}
+
+func selectorMatches(ls *metav1.LabelSelector, srcLabels map[string]string) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		klog.Infoln("invalid selector: ", ls)
+		return false, err
+	}
+	return selector.Matches(labels.Set(srcLabels)), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -782,7 +782,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.33.2-0.20230503123451-70ebcf524ed7
+# kubedb.dev/apimachinery v0.34.0-rc.0
 ## explicit; go 1.18
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
@@ -816,6 +816,7 @@ kubedb.dev/apimachinery/client/clientset/versioned/typed/postgres/v1alpha1
 kubedb.dev/apimachinery/client/clientset/versioned/typed/schema/v1alpha1
 kubedb.dev/apimachinery/client/clientset/versioned/typed/ui/v1alpha1
 kubedb.dev/apimachinery/crds
+kubedb.dev/apimachinery/pkg/double_optin
 kubedb.dev/apimachinery/pkg/validator
 # sigs.k8s.io/controller-runtime v0.13.1 => github.com/kmodules/controller-runtime v0.13.1-0.20220917045846-a0df7cc5e5ee
 ## explicit; go 1.17


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.06.13-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/70
Signed-off-by: 1gtm <1gtm@appscode.com>