### PR TITLE
Prepare for release v0.34.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	kmodules.xyz/client-go v0.25.23
 	kmodules.xyz/custom-resources v0.25.2
 	kmodules.xyz/monitoring-agent-api v0.25.1
-	kubedb.dev/apimachinery v0.34.0-rc.0
+	kubedb.dev/apimachinery v0.34.0
 	stash.appscode.dev/apimachinery v0.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1310,8 +1310,8 @@ kmodules.xyz/offshoot-api v0.25.4 h1:IjJNvkphcdYUG8XO/pBwXpuP8W+jxAWJZ3yH8vgI/as
 kmodules.xyz/offshoot-api v0.25.4/go.mod h1:PUk4EuJFhhyQykCflHj7EgXcljGIqs9vi0IN0RpxtY4=
 kmodules.xyz/prober v0.25.0 h1:R5uRLHJEvEtEoogj+vaTAob0Btph6+PX5IlS6hPh8PA=
 kmodules.xyz/prober v0.25.0/go.mod h1:z4RTnjaajNQa/vPltsiOnO3xI716I/ziD2ac2Exm+1M=
-kubedb.dev/apimachinery v0.34.0-rc.0 h1:U8iOIZPDZVg6yYl5k/mFdH38yXh8MLESP0DyZ+Uu8ww=
-kubedb.dev/apimachinery v0.34.0-rc.0/go.mod h1:bFkJ6mbKUpmvmfVML6dczw/+BEO8AMKcuWZckydR2Y0=
+kubedb.dev/apimachinery v0.34.0 h1:ve906AZanI47PD42xxqBulvA/sd+zSR4lu2Ff1P4+u8=
+kubedb.dev/apimachinery v0.34.0/go.mod h1:TEtf7k2WIKjka6IpXibsfFPONqAqOLELCta40Ox7a+c=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -782,7 +782,7 @@ kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.25.0
 ## explicit; go 1.18
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.34.0-rc.0
+# kubedb.dev/apimachinery v0.34.0
 ## explicit; go 1.18
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.06.19
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/71
Signed-off-by: 1gtm <1gtm@appscode.com>