### PR TITLE
Prepare for release v0.47.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module kubedb.dev/cli
 
 go 1.22.1
 
+toolchain go1.22.5
+
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/cert-manager/cert-manager v1.15.1


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.7.3-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/91
Signed-off-by: 1gtm <1gtm@appscode.com>