### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/connect/elasticsearch.go
+++ b/pkg/connect/elasticsearch.go
@@ -197,7 +197,8 @@ func (opts *elasticsearchOpts) getDockerShellCommand(localPort int, dockerFlags,
 			return nil, err
 		}
 
-		dockerCommand = append(dockerCommand,
+		dockerCommand = append(
+			dockerCommand,
 			"-e", fmt.Sprintf("ADDRESS=https://localhost:%d", localPort),
 			"-e", fmt.Sprintf("CACERT=%s", caFile),
 			"-e", fmt.Sprintf("CERT=%s", certFile),

--- a/pkg/connect/mariadb.go
+++ b/pkg/connect/mariadb.go
@@ -261,12 +261,14 @@ func (opts *mariadbOpts) getDockerShellCommand(localPort int, dockerFlags, mysql
 			return nil, err
 		}
 
-		dockerCommand = append(dockerCommand,
+		dockerCommand = append(
+			dockerCommand,
 			"-v", fmt.Sprintf("%s:%s", caFile, caFile),
 			"-v", fmt.Sprintf("%s:%s", certFile, certFile),
 			"-v", fmt.Sprintf("%s:%s", keyFile, keyFile),
 		)
-		mysqlCommand = append(mysqlCommand,
+		mysqlCommand = append(
+			mysqlCommand,
 			fmt.Sprintf("--ssl-ca=%v", caFile),
 			fmt.Sprintf("--ssl-cert=%v", certFile),
 			fmt.Sprintf("--ssl-key=%v", keyFile),

--- a/pkg/connect/memcached.go
+++ b/pkg/connect/memcached.go
@@ -122,7 +122,8 @@ func newMemcachedOpts(f cmdutil.Factory, dbName, namespace string) (*memcachedOp
 
 func (opts *memcachedOpts) connect(localPort int) error {
 	sh := shell.NewSession()
-	return sh.Command("docker", "run", "--network=host", "-it", "--entrypoint", "telnet",
+	return sh.Command(
+		"docker", "run", "--network=host", "-it", "--entrypoint", "telnet",
 		busyboxImg, "127.0.0.1", strconv.Itoa(localPort),
 	).SetStdin(os.Stdin).Run()
 }

--- a/pkg/connect/mongodb.go
+++ b/pkg/connect/mongodb.go
@@ -265,7 +265,8 @@ func (opts *mongodbOpts) getDockerShellCommand(localPort int, dockerFlags, mongo
 			return nil, err
 		}
 
-		dockerCommand = append(dockerCommand,
+		dockerCommand = append(
+			dockerCommand,
 			"-v", fmt.Sprintf("%s:%s", caFile, caFile),
 			"-v", fmt.Sprintf("%s:%s", pemFile, pemFile),
 		)

--- a/pkg/connect/mysql.go
+++ b/pkg/connect/mysql.go
@@ -263,12 +263,14 @@ func (opts *mysqlOpts) getDockerShellCommand(localPort int, dockerFlags, mysqlEx
 			return nil, err
 		}
 
-		dockerCommand = append(dockerCommand,
+		dockerCommand = append(
+			dockerCommand,
 			"-v", fmt.Sprintf("%s:%s", caFile, caFile),
 			"-v", fmt.Sprintf("%s:%s", certFile, certFile),
 			"-v", fmt.Sprintf("%s:%s", keyFile, keyFile),
 		)
-		mysqlCommand = append(mysqlCommand,
+		mysqlCommand = append(
+			mysqlCommand,
 			fmt.Sprintf("--ssl-ca=%v", caFile),
 			fmt.Sprintf("--ssl-cert=%v", certFile),
 			fmt.Sprintf("--ssl-key=%v", keyFile),

--- a/pkg/connect/postgres.go
+++ b/pkg/connect/postgres.go
@@ -278,7 +278,8 @@ func (opts *postgresOpts) getDockerShellCommand(localPort int, dockerFlags, post
 			return nil, err
 		}
 
-		dockerCommand = append(dockerCommand,
+		dockerCommand = append(
+			dockerCommand,
 			"-v", fmt.Sprintf("%s:%s", "/tmp/", "/root/.postgresql/"),
 		)
 	}

--- a/pkg/connect/redis.go
+++ b/pkg/connect/redis.go
@@ -213,9 +213,8 @@ func (opts *redisOpts) getShellCommand(kubectlFlags, redisExtraFlags []any) *she
 
 	db := opts.db
 	svcName := fmt.Sprintf("svc/%s", db.Name)
-	kubectlCommand := []any{
-		"exec", "-n", db.Namespace, svcName, "-c", "redis",
-	}
+	kubectlCommand := make([]any, 0, 6+len(kubectlFlags)+1)
+	kubectlCommand = append(kubectlCommand, "exec", "-n", db.Namespace, svcName, "-c", "redis")
 	kubectlCommand = append(kubectlCommand, kubectlFlags...)
 
 	redisCommand := []any{
@@ -292,9 +291,8 @@ func (opts *redisOpts) executeFile(fileName string) error {
 		return err
 	}
 
-	redisExtraFlags := []any{
-		"eval", string(fileData), fmt.Sprintf("%v", len(opts.keys)),
-	}
+	redisExtraFlags := make([]any, 0, 3+len(opts.keys)+len(opts.args))
+	redisExtraFlags = append(redisExtraFlags, "eval", string(fileData), fmt.Sprintf("%v", len(opts.keys)))
 	keysIfcArray := convertToInterfaceArray(opts.keys)
 	argsIfcArray := convertToInterfaceArray(opts.args)
 

--- a/pkg/connect/redis.go
+++ b/pkg/connect/redis.go
@@ -223,7 +223,8 @@ func (opts *redisOpts) getShellCommand(kubectlFlags, redisExtraFlags []any) *she
 	}
 
 	if db.Spec.TLS != nil {
-		redisCommand = append(redisCommand,
+		redisCommand = append(
+			redisCommand,
 			"--tls",
 			"--cert", "/certs/client.crt",
 			"--key", "/certs/client.key",

--- a/pkg/data/mongodb.go
+++ b/pkg/data/mongodb.go
@@ -357,7 +357,8 @@ func (opts *mongoDBOpts) getShellCommand(command string) (*shell.Session, error)
 		}
 		mgCommand = append(mgCommand, c...)
 	} else {
-		mgCommand = append(mgCommand,
+		mgCommand = append(
+			mgCommand,
 			KubeDBDatabaseName, "--quiet",
 			fmt.Sprintf("--username=%s", opts.username),
 			fmt.Sprintf("--password=%s", opts.pass),

--- a/pkg/data/redis.go
+++ b/pkg/data/redis.go
@@ -457,7 +457,8 @@ func (opts *redisOpts) getShellCommand(podIP string, redisCommand []any) *shell.
 	}
 
 	if db.Spec.TLS != nil {
-		redisBaseCommand = append(redisBaseCommand,
+		redisBaseCommand = append(
+			redisBaseCommand,
 			"--tls",
 			"--cert", "/certs/client.crt",
 			"--key", "/certs/client.key",

--- a/pkg/describer/describer.go
+++ b/pkg/describer/describer.go
@@ -144,7 +144,7 @@ func describeDeployment(d *appsv1.Deployment, running, waiting, succeeded, faile
 	w.Write(LEVEL_1, "CreationTimestamp:\t%s\n", timeToString(&d.CreationTimestamp))
 	printLabelsMultiline(LEVEL_1, w, "Labels", d.Labels)
 	printAnnotationsMultiline(LEVEL_1, w, "Annotations", d.Annotations)
-	w.Write(LEVEL_1, "Replicas:\t%d desired | %d updated | %d total | %d available | %d unavailable\n", *(d.Spec.Replicas), d.Status.UpdatedReplicas, d.Status.Replicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
+	w.Write(LEVEL_1, "Replicas:\t%d desired | %d updated | %d total | %d available | %d unavailable\n", *d.Spec.Replicas, d.Status.UpdatedReplicas, d.Status.Replicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 	w.Write(LEVEL_1, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
 }
 
@@ -574,7 +574,8 @@ func DescribeEvents(el *core.EventList, w describe.PrefixWriter) {
 		} else {
 			interval = translateTimestamp(e.FirstTimestamp)
 		}
-		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
+		w.Write(
+			LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,
 			e.Reason,
 			interval,

--- a/pkg/describer/helper.go
+++ b/pkg/describer/helper.go
@@ -274,7 +274,8 @@ func showTopology(client kubernetes.Interface, namespace string, selector labels
 				types = append(types, key)
 			}
 		}
-		w.Write(LEVEL_0, "  %s\t%s\t%s\t%s\n",
+		w.Write(
+			LEVEL_0, "  %s\t%s\t%s\t%s\n",
 			strings.Join(types, "|"),
 			pod.Name,
 			pod.Status.StartTime,

--- a/pkg/describer/helper.go
+++ b/pkg/describer/helper.go
@@ -129,7 +129,7 @@ func showAppBinding(ab *appcat.AppBinding, w describe.PrefixWriter) error {
 }
 
 func printUnstructuredContent(w describe.PrefixWriter, level int, content map[string]any, skipPrefix string, skip ...string) {
-	fields := []string{}
+	fields := make([]string, 0, len(content))
 	for field := range content {
 		fields = append(fields, field)
 	}

--- a/pkg/remote_replica/mysql.go
+++ b/pkg/remote_replica/mysql.go
@@ -327,7 +327,8 @@ func ensureMySQLClientCert(opts *common.MySQLOpts, apb *appApi.AppBinding, mysql
 			}
 
 			return in
-		}, metav1.PatchOptions{})
+		}, metav1.PatchOptions{},
+	)
 
 	return vt, err
 }

--- a/pkg/remote_replica/mysql.go
+++ b/pkg/remote_replica/mysql.go
@@ -161,7 +161,6 @@ func generateMySQLConfig(f cmdutil.Factory, userName string, password string, dn
 }
 
 func generateMySQLTlsSecret(userName string, apb *appApi.AppBinding, ns string, opts *common.MySQLOpts) ([]byte, string, error) {
-	var buffer []byte
 	_, err := ensureMySQLClientCert(opts, apb, opts.DB, dbapi.MySQLClientCert, userName)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to ensure client cert %v", err)
@@ -192,6 +191,7 @@ func generateMySQLTlsSecret(userName string, apb *appApi.AppBinding, ns string, 
 		return nil, "", fmt.Errorf("failed to marshal tls secret yaml %v", err)
 	}
 
+	buffer := make([]byte, 0, len(tlsSecretYaml)+4)
 	buffer = append(buffer, tlsSecretYaml...)
 	buffer = append(buffer, []byte("---\n")...)
 
@@ -199,7 +199,6 @@ func generateMySQLTlsSecret(userName string, apb *appApi.AppBinding, ns string, 
 }
 
 func generateMySQLAuthSecret(userName string, password string, ns string, opts *common.MySQLOpts) ([]byte, string, error) {
-	var buffer []byte
 	if userName != opts.Username {
 		// generate user if not present
 		err := generateMySQLUser(opts, userName, password)
@@ -230,6 +229,7 @@ func generateMySQLAuthSecret(userName string, password string, ns string, opts *
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal authsecret yaml %v", err)
 	}
+	buffer := make([]byte, 0, len(authSecretYaml)+4)
 	buffer = append(buffer, authSecretYaml...)
 	buffer = append(buffer, []byte("---\n")...)
 	return buffer, AuthSecret.Name, nil

--- a/pkg/remote_replica/postgres.go
+++ b/pkg/remote_replica/postgres.go
@@ -157,7 +157,6 @@ func generateConfig(f cmdutil.Factory, userName string, password string, dns str
 }
 
 func generateTlsSecret(userName string, apb *appApi.AppBinding, ns string, opts *common.PostgresOpts) ([]byte, string, error) {
-	var buffer []byte
 	_, err := ensureClientCert(opts, apb, opts.DB, dbapi.PostgresClientCert, userName)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to ensure client cert %v", err)
@@ -188,6 +187,7 @@ func generateTlsSecret(userName string, apb *appApi.AppBinding, ns string, opts 
 		return nil, "", fmt.Errorf("failed to marshal tls secret yaml %v", err)
 	}
 
+	buffer := make([]byte, 0, len(tlsSecretYaml)+4)
 	buffer = append(buffer, tlsSecretYaml...)
 	buffer = append(buffer, []byte("---\n")...)
 
@@ -195,7 +195,6 @@ func generateTlsSecret(userName string, apb *appApi.AppBinding, ns string, opts 
 }
 
 func generateAuthSecret(userName string, password string, ns string, opts *common.PostgresOpts) ([]byte, string, error) {
-	var buffer []byte
 	if userName != opts.Username {
 		// generate user if not present
 		err := generateUser(opts, userName, password)
@@ -226,6 +225,7 @@ func generateAuthSecret(userName string, password string, ns string, opts *commo
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal authsecret yaml %v", err)
 	}
+	buffer := make([]byte, 0, len(authSecretYaml)+4)
 	buffer = append(buffer, authSecretYaml...)
 	buffer = append(buffer, []byte("---\n")...)
 	return buffer, AuthSecret.Name, nil

--- a/pkg/remote_replica/postgres.go
+++ b/pkg/remote_replica/postgres.go
@@ -338,7 +338,8 @@ func ensureClientCert(opts *common.PostgresOpts, apb *appApi.AppBinding, postgre
 			}
 
 			return in
-		}, metav1.PatchOptions{})
+		}, metav1.PatchOptions{},
+	)
 
 	return vt, err
 }


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
